### PR TITLE
fixed requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 certifi==2020.6.20
 chardet==3.0.4
 idna==2.10
-pkg-resources==0.0.0
 requests==2.24.0
 urllib3==1.25.10


### PR DESCRIPTION
@YoussefMIbrahim 
I fixed crash when installing requirements.txt crashed on 'pkg-resources == 0.0.0' as that does not exist. Deleted that line. Is there a reason you included it?